### PR TITLE
Automatically select last used app feature

### DIFF
--- a/src/appfinder-model.c
+++ b/src/appfinder-model.c
@@ -2002,7 +2002,7 @@ xfce_appfinder_model_collect_thread (gpointer user_data)
     {
       model->collect_items = g_slist_sort (model->collect_items, xfce_appfinder_model_item_compare);
       model->collect_categories = g_slist_sort (model->collect_categories, xfce_appfinder_model_category_compare);
-      
+
       model->collect_idle_id = gdk_threads_add_idle_full (G_PRIORITY_LOW, xfce_appfinder_model_collect_idle,
                                                 model, xfce_appfinder_model_collect_idle_destroy);
     }

--- a/src/appfinder-model.c
+++ b/src/appfinder-model.c
@@ -815,8 +815,6 @@ xfce_appfinder_model_collect_idle (gpointer user_data)
             item->recency = *((guint64 *)item_recency_ptr);
           else
             item->recency = 0;
-          
-          APPFINDER_DEBUG ("item_recency_ptr %" G_GUINT64_FORMAT, item->recency);
         }
 
       /* insert in hash table */
@@ -2086,7 +2084,6 @@ xfce_appfinder_model_recency_collect   (XfceAppfinderModel  *model,
         {
           line = g_strndup (contents, end - contents);
           line_contents = g_strsplit (line, ":", 2);
-          APPFINDER_DEBUG ("Desktop id: %s, has recency of: %s", line_contents[0], line_contents[1]);
           if (line_contents[0] != NULL && line_contents[1] != NULL)
             {
               recency_ptr = g_new0 (guint64 , 1);
@@ -2132,8 +2129,6 @@ xfce_appfinder_model_update_frecency (XfceAppfinderModel *model,
       if (item->item == NULL)
         continue;
 
-      APPFINDER_DEBUG ("item frequency : %d", item->frequency);
-      APPFINDER_DEBUG ("item recency: %ld", item->recency);
       desktop_id2 = garcon_menu_item_get_desktop_id (item->item);
       /* find the item we're trying to add/remove */
       if (desktop_id != NULL)

--- a/src/appfinder-model.c
+++ b/src/appfinder-model.c
@@ -2016,11 +2016,9 @@ xfce_appfinder_model_frequency_collect (XfceAppfinderModel  *model,
               /* look for new commands */
               item = li->data;
               line = g_strndup (contents, end - contents);
-              if (item->item != NULL)
-                {
-                  item->frequency = g_ascii_strtoull (line, NULL, 0);
-                  APPFINDER_DEBUG ("Frequency of the item : %d", item->frequency);
-                }
+              APPFINDER_DEBUG ("%s", line);
+              item->frequency = g_ascii_strtoull (line, NULL, 0);
+              APPFINDER_DEBUG ("Frequency of the item : %d", item->frequency);
             }
           contents = end + 1;
         }

--- a/src/appfinder-model.c
+++ b/src/appfinder-model.c
@@ -2015,12 +2015,15 @@ xfce_appfinder_model_frequency_collect (XfceAppfinderModel  *model,
             {
               /* look for new commands */
               item = li->data;
-              line = g_strndup (contents, end - contents);
-              APPFINDER_DEBUG ("%s", line);
-              item->frequency = g_ascii_strtoull (line, NULL, 0);
-              APPFINDER_DEBUG ("Frequency of the item : %d", item->frequency);
+              if (item->item != NULL)
+                {
+                  line = g_strndup (contents, end - contents);
+                  APPFINDER_DEBUG ("%s", line);
+                  item->frequency = g_ascii_strtoull (line, NULL, 0);
+                  APPFINDER_DEBUG ("Frequency of the item: %d", item->frequency);
+                  contents = end + 1;
+                }
             }
-          contents = end + 1;
         }
     }
 }
@@ -2053,6 +2056,7 @@ xfce_appfinder_model_update_frequency (XfceAppfinderModel *model,
       if (item->item == NULL)
         continue;
 
+      APPFINDER_DEBUG ("item frequency : %d", item->frequency);
       /* find the item we're trying to add/remove */
       if (desktop_id != NULL)
         {

--- a/src/appfinder-model.c
+++ b/src/appfinder-model.c
@@ -961,7 +961,7 @@ xfce_appfinder_model_item_changed (GarconMenuItem     *menu_item,
   gboolean     old_not_visible;
   const gchar *desktop_id;
   guint        item_frequency;
-  guint64     *item_recency;
+  gpointer    *item_recency;
 
   /* lookup the item in the list */
   for (li = model->items, idx = 0; li != NULL; li = li->next, idx++)
@@ -988,14 +988,14 @@ xfce_appfinder_model_item_changed (GarconMenuItem     *menu_item,
             {
               item->is_bookmark = g_hash_table_lookup (model->bookmarks_hash, desktop_id) != NULL;
               item_frequency = GPOINTER_TO_UINT(g_hash_table_lookup (model->frequencies_hash, desktop_id));
-              item_recency = ((guint64 *) g_hash_table_lookup (model->recencies_hash, desktop_id));
+              item_recency =  g_hash_table_lookup (model->recencies_hash, desktop_id);
               if (item_frequency)
                 item->frequency = item_frequency;
               else
                 item->frequency = 0;
                 
               if (item_recency)
-                item->recency = *item_recency;
+                item->recency = *((guint64 *)item_recency);
               else
                 item->recency = 0;
             }
@@ -2050,6 +2050,8 @@ xfce_appfinder_model_frequency_collect (XfceAppfinderModel  *model,
               frequency = g_ascii_strtoull (line_contents[1], NULL, 0);
               g_hash_table_insert (model->frequencies_hash, line_contents[0], GUINT_TO_POINTER (frequency));
             }
+          
+          g_free (line);
         }
         
       contents = end + 1;
@@ -2091,6 +2093,8 @@ xfce_appfinder_model_recency_collect   (XfceAppfinderModel  *model,
               *recency_ptr = recency;
               g_hash_table_insert (model->recencies_hash, line_contents[0], recency_ptr);
             }
+          
+          g_free (line);
         }
         
       contents = end + 1;

--- a/src/appfinder-model.c
+++ b/src/appfinder-model.c
@@ -2032,12 +2032,13 @@ xfce_appfinder_model_frequency_collect (XfceAppfinderModel  *model,
 
 void
 xfce_appfinder_model_update_frequency (XfceAppfinderModel *model,
-                                       const gchar        *desktop_id)
+                                       const gchar        *desktop_id,
+                                       GError            **error)
 {
   ModelItem    *item;
   GSList       *li;
   const gchar  *desktop_id2;
-  static gsize  old_len = 0;
+  // static gsize  old_len = 0;
   GString      *contents;
   gchar        *filename;
   GtkTreePath  *path;
@@ -2045,9 +2046,11 @@ xfce_appfinder_model_update_frequency (XfceAppfinderModel *model,
   GtkTreeIter   iter;
 
   appfinder_return_if_fail (XFCE_IS_APPFINDER_MODEL (model));
+  appfinder_return_if_fail (error == NULL || *error == NULL);
   appfinder_return_if_fail (desktop_id != NULL);
 
-  contents = g_string_sized_new (old_len);
+  // contents = g_string_sized_new (old_len);
+  contents = g_string_sized_new (0);
 
   /* update the model items */
   for (idx = 0, li = model->items; li != NULL; li = li->next, idx++)
@@ -2094,11 +2097,11 @@ xfce_appfinder_model_update_frequency (XfceAppfinderModel *model,
     }
   else
     {
-      APPFINDER_DEBUG ("Unable to create frequency file");
+      g_set_error_literal (error, 0, 0, "Unable to create bookmarks file");
     }
 
   /* optimization for next run */
-  old_len = contents->allocated_len;
+  // old_len = contents->allocated_len;
 
   g_free (filename);
   g_string_free (contents, TRUE);

--- a/src/appfinder-model.c
+++ b/src/appfinder-model.c
@@ -103,8 +103,6 @@ static void               xfce_appfinder_model_bookmarks_monitor      (XfceAppfi
 
 static gboolean           xfce_appfinder_model_fuzzy_match            (const gchar              *source,
                                                                        const gchar              *token);
-
-// static void               xfce_appfinder_model_load_frequency         (XfceAppfinderModel       *model);
 static void               xfce_appfinder_model_frequency_collect      (XfceAppfinderModel       *model,
                                                                        GMappedFile              *mmap);
 
@@ -1966,52 +1964,6 @@ xfce_appfinder_model_collect_thread (gpointer user_data)
   APPFINDER_DEBUG ("collect thread end");
 
   return NULL;
-}
-
-
-
-static void
-xfce_appfinder_model_load_frequency (XfceAppfinderModel *model)
-{
-  GError             *error = NULL;
-  gchar              *filename;
-  GMappedFile        *mmap;
-  ModelItem          *item;
-  GSList             *li;
-
-  filename = xfce_resource_lookup (XFCE_RESOURCE_CONFIG, FREQUENCY_PATH);
-  if (G_LIKELY (filename != NULL))
-    {
-      APPFINDER_DEBUG ("load frequency from %s", filename);
-
-      mmap = g_mapped_file_new (filename, FALSE, &error);
-      if (G_LIKELY (mmap != NULL))
-        {
-          xfce_appfinder_model_frequency_collect (model, mmap);
-          g_mapped_file_unref (mmap);
-        }
-      else
-        {
-          g_warning ("Failed to open frequency file: %s", error->message);
-          g_clear_error (&error);
-        }
-
-      g_free (filename);
-    }
-  else
-    {
-      APPFINDER_DEBUG ("File not found case");
-      APPFINDER_DEBUG ("===================");
-      for (li = model->collect_items; li; li = li->next)
-        {
-          item = li->data;
-          if (item->item != NULL)
-            {
-              item->frequency = 0;
-              APPFINDER_DEBUG ("Frequency of the item : %d", item->frequency);
-            }
-        }
-    }
 }
 
 

--- a/src/appfinder-model.h
+++ b/src/appfinder-model.h
@@ -109,8 +109,9 @@ gboolean             xfce_appfinder_model_bookmark_toggle        (XfceAppfinderM
 GarconMenuDirectory *xfce_appfinder_model_get_command_category   (void);
 
 GarconMenuDirectory *xfce_appfinder_model_get_bookmarks_category (void);
-void                      xfce_appfinder_model_update_frequency  (XfceAppfinderModel       *model,
-                                                                  const gchar              *desktop_id);
+void                 xfce_appfinder_model_update_frequency       (XfceAppfinderModel       *model,
+                                                                  const gchar               *desktop_id,
+                                                                  GError                   **error);
 
 G_END_DECLS
 

--- a/src/appfinder-model.h
+++ b/src/appfinder-model.h
@@ -44,6 +44,7 @@ enum
   XFCE_APPFINDER_MODEL_COLUMN_URI,
   XFCE_APPFINDER_MODEL_COLUMN_BOOKMARK,
   XFCE_APPFINDER_MODEL_COLUMN_FREQUENCY,
+  XFCE_APPFINDER_MODEL_COLUMN_RECENCY,
   XFCE_APPFINDER_MODEL_COLUMN_TOOLTIP,
   XFCE_APPFINDER_MODEL_N_COLUMNS,
 };
@@ -109,9 +110,9 @@ gboolean             xfce_appfinder_model_bookmark_toggle        (XfceAppfinderM
 GarconMenuDirectory *xfce_appfinder_model_get_command_category   (void);
 
 GarconMenuDirectory *xfce_appfinder_model_get_bookmarks_category (void);
-void                 xfce_appfinder_model_update_frequency       (XfceAppfinderModel       *model,
-                                                                  const gchar               *desktop_id,
-                                                                  GError                   **error);
+void                 xfce_appfinder_model_update_frecency        (XfceAppfinderModel       *model,
+                                                                  const gchar              *desktop_id,
+                                                                  GError                  **error);
 
 G_END_DECLS
 

--- a/src/appfinder-model.h
+++ b/src/appfinder-model.h
@@ -43,6 +43,7 @@ enum
   XFCE_APPFINDER_MODEL_COLUMN_COMMAND,
   XFCE_APPFINDER_MODEL_COLUMN_URI,
   XFCE_APPFINDER_MODEL_COLUMN_BOOKMARK,
+  XFCE_APPFINDER_MODEL_COLUMN_FREQUENCY,
   XFCE_APPFINDER_MODEL_COLUMN_TOOLTIP,
   XFCE_APPFINDER_MODEL_N_COLUMNS,
 };
@@ -108,6 +109,8 @@ gboolean             xfce_appfinder_model_bookmark_toggle        (XfceAppfinderM
 GarconMenuDirectory *xfce_appfinder_model_get_command_category   (void);
 
 GarconMenuDirectory *xfce_appfinder_model_get_bookmarks_category (void);
+void                      xfce_appfinder_model_update_frequency  (XfceAppfinderModel       *model,
+                                                                  const gchar              *desktop_id);
 
 G_END_DECLS
 

--- a/src/appfinder-preferences.c
+++ b/src/appfinder-preferences.c
@@ -134,6 +134,10 @@ xfce_appfinder_preferences_init (XfceAppfinderPreferences *preferences)
       G_CALLBACK (xfce_appfinder_preferences_single_window_sensitive), object);
   xfce_appfinder_preferences_single_window_sensitive (GTK_WIDGET (previous), GTK_WIDGET (object));
 
+  object = gtk_builder_get_object (GTK_BUILDER (preferences), "recent-order");
+  xfconf_g_property_bind (preferences->channel, "/recent-order", G_TYPE_BOOLEAN,
+                          G_OBJECT (object), "active");
+
   previous = gtk_builder_get_object (GTK_BUILDER (preferences), "icon-view");
   xfconf_g_property_bind (preferences->channel, "/icon-view", G_TYPE_BOOLEAN,
                           G_OBJECT (previous), "active");

--- a/src/appfinder-preferences.glade
+++ b/src/appfinder-preferences.glade
@@ -77,15 +77,31 @@
     <property name="icon_name">gtk-preferences</property>
     <property name="type_hint">dialog</property>
     <child internal-child="vbox">
-      <object class="GtkBox" id="dialog-vbox1">
+      <object class="GtkVBox" id="dialog-vbox1">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="spacing">2</property>
         <child internal-child="action_area">
-          <object class="GtkButtonBox" id="dialog-action_area1">
+          <object class="GtkHButtonBox" id="dialog-action_area1">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>
+            <child>
+              <object class="GtkButton" id="button-close">
+                <property name="label">_Close</property>
+                <property name="use_action_appearance">False</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="image">image4</property>
+                <property name="use_underline">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
             <child>
               <object class="GtkButton" id="button-help">
                 <property name="label">_Help</property>
@@ -101,22 +117,6 @@
                 <property name="fill">False</property>
                 <property name="position">0</property>
                 <property name="secondary">True</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="button-close">
-                <property name="label">_Close</property>
-                <property name="use_action_appearance">False</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="image">image4</property>
-                <property name="use_underline">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
               </packing>
             </child>
           </object>
@@ -338,9 +338,11 @@
                                 <property name="receives_default">False</property>
                                 <property name="tooltip_text" translatable="yes">Hide category panel and show all applications.</property>
                                 <property name="use_underline">True</property>
+                                <property name="active">False</property>
                                 <property name="draw_indicator">True</property>
                               </object>
                               <packing>
+                                <property name="left_attach">0</property>
                                 <property name="right_attach">2</property>
                                 <property name="top_attach">3</property>
                                 <property name="bottom_attach">4</property>
@@ -610,9 +612,6 @@
                     <property name="column_spacing">12</property>
                     <property name="row_spacing">6</property>
                     <child>
-                      <placeholder/>
-                    </child>
-                    <child>
                       <object class="GtkEntry" id="command">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
@@ -703,6 +702,9 @@
                       </packing>
                     </child>
                     <child>
+                      <placeholder/>
+                    </child>
+                    <child>
                       <object class="GtkComboBox" id="type">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
@@ -754,8 +756,8 @@
       </object>
     </child>
     <action-widgets>
-      <action-widget response="-11">button-help</action-widget>
       <action-widget response="0">button-close</action-widget>
+      <action-widget response="-11">button-help</action-widget>
     </action-widgets>
   </object>
 </interface>

--- a/src/appfinder-preferences.glade
+++ b/src/appfinder-preferences.glade
@@ -77,31 +77,15 @@
     <property name="icon_name">gtk-preferences</property>
     <property name="type_hint">dialog</property>
     <child internal-child="vbox">
-      <object class="GtkVBox" id="dialog-vbox1">
+      <object class="GtkBox" id="dialog-vbox1">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="spacing">2</property>
         <child internal-child="action_area">
-          <object class="GtkHButtonBox" id="dialog-action_area1">
+          <object class="GtkButtonBox" id="dialog-action_area1">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>
-            <child>
-              <object class="GtkButton" id="button-close">
-                <property name="label">_Close</property>
-                <property name="use_action_appearance">False</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="image">image4</property>
-                <property name="use_underline">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
             <child>
               <object class="GtkButton" id="button-help">
                 <property name="label">_Help</property>
@@ -117,6 +101,22 @@
                 <property name="fill">False</property>
                 <property name="position">0</property>
                 <property name="secondary">True</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="button-close">
+                <property name="label">_Close</property>
+                <property name="use_action_appearance">False</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="image">image4</property>
+                <property name="use_underline">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
               </packing>
             </child>
           </object>
@@ -224,6 +224,23 @@
                                 <property name="position">3</property>
                               </packing>
                             </child>
+                            <child>
+                              <object class="GtkCheckButton" id="recent-order">
+                                <property name="label" translatable="yes"> Automatically select recently used item</property>
+                                <property name="use_action_appearance">False</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="tooltip_text" translatable="yes">Order items, such that items that are most recently used are always on the top.</property>
+                                <property name="use_underline">True</property>
+                                <property name="draw_indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">4</property>
+                              </packing>
+                            </child>
                           </object>
                         </child>
                       </object>
@@ -321,11 +338,9 @@
                                 <property name="receives_default">False</property>
                                 <property name="tooltip_text" translatable="yes">Hide category panel and show all applications.</property>
                                 <property name="use_underline">True</property>
-                                <property name="active">False</property>
                                 <property name="draw_indicator">True</property>
                               </object>
                               <packing>
-                                <property name="left_attach">0</property>
                                 <property name="right_attach">2</property>
                                 <property name="top_attach">3</property>
                                 <property name="bottom_attach">4</property>
@@ -595,6 +610,9 @@
                     <property name="column_spacing">12</property>
                     <property name="row_spacing">6</property>
                     <child>
+                      <placeholder/>
+                    </child>
+                    <child>
                       <object class="GtkEntry" id="command">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
@@ -685,9 +703,6 @@
                       </packing>
                     </child>
                     <child>
-                      <placeholder/>
-                    </child>
-                    <child>
                       <object class="GtkComboBox" id="type">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
@@ -739,8 +754,8 @@
       </object>
     </child>
     <action-widgets>
-      <action-widget response="0">button-close</action-widget>
       <action-widget response="-11">button-help</action-widget>
+      <action-widget response="0">button-close</action-widget>
     </action-widgets>
   </object>
 </interface>

--- a/src/appfinder-window.c
+++ b/src/appfinder-window.c
@@ -710,9 +710,7 @@ xfce_appfinder_window_view (XfceAppfinderWindow *window)
 
   window->sort_model = gtk_tree_model_sort_new_with_model (GTK_TREE_MODEL (window->filter_model));
   if (xfconf_channel_get_bool (window->channel, "/recent-order", FALSE))
-
     gtk_tree_sortable_set_default_sort_func (GTK_TREE_SORTABLE (window->sort_model), xfce_appfinder_window_sort_items_frecency, window->entry, NULL);
-
   else
     gtk_tree_sortable_set_default_sort_func (GTK_TREE_SORTABLE (window->sort_model), xfce_appfinder_window_sort_items, window->entry, NULL);
 

--- a/src/appfinder-window.c
+++ b/src/appfinder-window.c
@@ -710,10 +710,9 @@ xfce_appfinder_window_view (XfceAppfinderWindow *window)
 
   window->sort_model = gtk_tree_model_sort_new_with_model (GTK_TREE_MODEL (window->filter_model));
   if (xfconf_channel_get_bool (window->channel, "/recent-order", FALSE))
-    {
-      gtk_tree_sortable_set_default_sort_func (GTK_TREE_SORTABLE (window->sort_model), xfce_appfinder_window_sort_items_frecency, window->entry, NULL);
-      APPFINDER_DEBUG ("===== HERE ====");
-    }
+
+    gtk_tree_sortable_set_default_sort_func (GTK_TREE_SORTABLE (window->sort_model), xfce_appfinder_window_sort_items_frecency, window->entry, NULL);
+
   else
     gtk_tree_sortable_set_default_sort_func (GTK_TREE_SORTABLE (window->sort_model), xfce_appfinder_window_sort_items, window->entry, NULL);
 
@@ -1926,6 +1925,7 @@ xfce_appfinder_window_update_frecency (XfceAppfinderWindow *window,
       xfce_appfinder_model_update_frecency (XFCE_APPFINDER_MODEL (model), desktop_id, &error);
 
       g_free (desktop_id);
+      g_free (error);
     }
 }
 
@@ -2047,7 +2047,6 @@ xfce_appfinder_window_sort_items_frecency  (GtkTreeModel *model,
   date_time_now = g_date_time_new_now_local ();
   unix_time_now = g_date_time_to_unix (date_time_now);
   g_date_time_unref (date_time_now);
-  APPFINDER_DEBUG ("Time now: %ld", unix_time_now);
 
   gtk_tree_model_get (model, a,
                       XFCE_APPFINDER_MODEL_COLUMN_FREQUENCY, &a_freq,
@@ -2062,12 +2061,9 @@ xfce_appfinder_window_sort_items_frecency  (GtkTreeModel *model,
   gtk_tree_model_get (model, b,
                       XFCE_APPFINDER_MODEL_COLUMN_RECENCY, &b_rec,
                       -1);
-  APPFINDER_DEBUG ("A freq: %d", a_freq);
-  APPFINDER_DEBUG ("B freq: %d", b_freq);
-  APPFINDER_DEBUG ("A rec: %ld", a_rec);
-  APPFINDER_DEBUG ("B rec: %ld", b_rec);
+
   diff = unix_time_now - a_rec;
-  APPFINDER_DEBUG ("diff a: %ld", diff);
+
   if (diff < 3600)
     a_res = a_freq * 4;
   else if (diff < 86400)
@@ -2078,7 +2074,7 @@ xfce_appfinder_window_sort_items_frecency  (GtkTreeModel *model,
     a_res = a_freq / 4;
   
   diff = unix_time_now - b_rec;
-  APPFINDER_DEBUG ("diff b: %ld", diff);
+
   if (diff < 3600)
     b_res = b_freq * 4;
   else if (diff < 86400)
@@ -2087,9 +2083,6 @@ xfce_appfinder_window_sort_items_frecency  (GtkTreeModel *model,
     b_res = b_freq / 2;
   else
     b_res = b_freq / 4;
-  
-  APPFINDER_DEBUG ("diff between now and a: %d", a_res);
-  APPFINDER_DEBUG ("diff between now and b: %d", b_res);
 
   return b_res - a_res;
 }

--- a/src/appfinder-window.c
+++ b/src/appfinder-window.c
@@ -709,7 +709,7 @@ xfce_appfinder_window_view (XfceAppfinderWindow *window)
   gtk_tree_model_filter_set_visible_func (GTK_TREE_MODEL_FILTER (window->filter_model), xfce_appfinder_window_item_visible, window, NULL);
 
   window->sort_model = gtk_tree_model_sort_new_with_model (GTK_TREE_MODEL (window->filter_model));
-  gtk_tree_sortable_set_default_sort_func (GTK_TREE_SORTABLE (window->sort_model), xfce_appfinder_window_sort_items_frequency, window->entry, NULL);
+  gtk_tree_sortable_set_default_sort_func (GTK_TREE_SORTABLE (window->sort_model), xfce_appfinder_window_sort_items, window->entry, NULL);
 
   if (icon_view)
     {
@@ -1219,12 +1219,14 @@ xfce_appfinder_window_entry_changed_idle (gpointer data)
 
       if (IS_STRING (text))
         {
+          gtk_tree_sortable_set_sort_column_id (GTK_TREE_SORTABLE (window->sort_model), XFCE_APPFINDER_MODEL_COLUMN_FREQUENCY, GTK_SORT_DESCENDING);
           normalized = g_utf8_normalize (text, -1, G_NORMALIZE_ALL);
           window->filter_text = g_utf8_casefold (normalized, -1);
           g_free (normalized);
         }
       else
         {
+          gtk_tree_sortable_set_sort_column_id (GTK_TREE_SORTABLE (window->sort_model), GTK_TREE_SORTABLE_DEFAULT_SORT_COLUMN_ID, GTK_SORT_ASCENDING);
           window->filter_text = NULL;
         }
 


### PR DESCRIPTION
Hi @andreldm, 
This is a feature implementation that fixes [Bug 9265](https://bugzilla.xfce.org/show_bug.cgi?id=9265), it's an implementation of the Frecency Algorithm, by keeping track of the item's frequency, and recency, the Frecency is then calculated using these two members according to the algorithm described [here](https://github.com/rupa/z/wiki/frecency).

I've also included it as an option for the user whether to sort items according to the most recent/used order, otherwise it's set by default to be based on the alphabetical order.

I'll be waiting for your review and comments, thanks